### PR TITLE
Update metaUrlPath to _snowpack

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -24,6 +24,6 @@ module.exports = {
     /* ... */
   },
   buildOptions: {
-    metaUrlPath: ".snowpack",
+    metaUrlPath: "_snowpack",
   },
 };


### PR DESCRIPTION
In `build`, the dirname when set to `.snowpack` is ignored by chrome store upon submission and should be manually changed to `snowpack` and update all the JS where `.snowpack` is used to `snowpack` in everybuild.

Changing to _snowpack by default.