### PR TITLE
Update metaUrlPath to @snowpack

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -24,6 +24,6 @@ module.exports = {
     /* ... */
   },
   buildOptions: {
-    metaUrlPath: "_snowpack",
+    metaUrlPath: "@snowpack",
   },
 };


### PR DESCRIPTION
In build, the dirname when set to `.snowpack` is ignored by chrome store upon submission and should be manually changed to snowpack and update all the JS where `.snowpack` is `snowpack` in every build.

When set to `_snowpack`,  Chrome ignore the extension all together in development mode, with a warning that `_` is reserved for system file/dir names

Changing to @snowpack by default.
